### PR TITLE
Ignore ssl

### DIFF
--- a/pwned-detective.py
+++ b/pwned-detective.py
@@ -5,6 +5,11 @@
 import argparse
 import base64
 import urllib2
+import ssl
+
+ctx = ssl.create_default_context()
+ctx.check_hostname = False
+ctx.verify_mode = ssl.CERT_NONE
 
 
 def display_banner():
@@ -45,7 +50,7 @@ def poc(hostname, file):
 
 
 def http_read(url):
-    return urllib2.urlopen(url).read()
+    return urllib2.urlopen(url, context=ctx).read()
 
 if __name__ == "__main__":
     display_banner()


### PR DESCRIPTION
If the EDetective server has incorrectly configured SSL, urllib2 will refuse to continue by default. This fixes that.

From StackOverflow: http://stackoverflow.com/a/28048260
